### PR TITLE
DEVOPS-596-send-in-the-payload-on-label

### DIFF
--- a/src/labeledPr.js
+++ b/src/labeledPr.js
@@ -1,6 +1,7 @@
 aha.on(
   { event: "aha-develop.github.pr.labeled" },
-  async ({ record, label, payload }) => {
+  async ({ record, payload }) => {
+    let label = payload["label"];
     console.log(record);
     console.log(label);
 

--- a/src/webhook.js
+++ b/src/webhook.js
@@ -24,7 +24,6 @@ async function handlePullRequest(payload) {
   if (record) {
     aha.triggerServer(`aha-develop.github.pr.${payload.action}`, {
       record: record,
-      label: payload["label"],
       payload: payload,
     });
   }


### PR DESCRIPTION
Dearest Reviewer,

I now see this is for all events not just labeled.. I think we should
pass in the original payload and let the caller pick out what they need.
for example i know I need the pull requests html_link.

changes
pass the payload
update the label code only. not sure if this kills the rest of it?

Becker