### PR TITLE
DEVELOP-244-3: Link to Aha! record

### DIFF
--- a/src/components/Styles.js
+++ b/src/components/Styles.js
@@ -172,6 +172,27 @@ const Styles = () => {
           font-size: 18px;
           line-height: 21px;
         }
+
+        .record-table--feature-link {
+          font-size: 90%;
+          color: var(--aha-gray-700);
+          padding-left: 5px;
+        }
+
+        .record-table--feature-link .bottom-left {
+          margin-right: 3px;
+          display: inline-block;
+          width: 6px;
+          height: 6px;
+          border-left: 1px solid var(--aha-gray-700);
+          border-bottom: 1px solid var(--aha-gray-700);
+          position: relative;
+          top: 2px;
+        }
+
+        .record-table--feature-link a {
+          color: var(--aha-gray-700);
+        }
       `}
     </style>
   );

--- a/src/components/page/PrTable.js
+++ b/src/components/page/PrTable.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { prStatusCommit, searchForPr } from "../../lib/github";
 import { useGithubApi } from "../../lib/useGithubApi";
 import ExternalLink from "../ExternalLink";
@@ -6,11 +6,30 @@ import { PrReviewStatus } from "../PrReviewStatus";
 import PrState from "../PrState";
 import { Status } from "../Status";
 
-const PrRow = ({ pr }) => {
+/**
+ * @typedef RowProps
+ * @prop {import('../../lib/github').PrForLink} pr
+ * @prop {Aha.Feature=} feature
+ */
+
+/**
+ * @type {React.FC<RowProps>}
+ */
+const PrRow = ({ pr, feature }) => {
   return (
     <tr>
       <td style={{ textOverflow: "ellipsis" }}>
-        <ExternalLink href={pr.url}>{pr.title}</ExternalLink>
+        <div>
+          <ExternalLink href={pr.url}>{pr.title}</ExternalLink>
+        </div>
+        {feature && (
+          <div className="record-table--feature-link">
+            <span className="bottom-left">&nbsp;</span>
+            <a href={feature.path}>
+              {feature.referenceNum} {feature.name}
+            </a>
+          </div>
+        )}
       </td>
       <td>
         <PrState pr={pr} />
@@ -26,7 +45,7 @@ const PrRow = ({ pr }) => {
 };
 
 const PrTable = ({ query }) => {
-  const response = useGithubApi(
+  const { authed, error, loading, data } = useGithubApi(
     async (api) => {
       const { edges } = await searchForPr(api, {
         query,
@@ -39,11 +58,57 @@ const PrTable = ({ query }) => {
     {},
     [query]
   );
+  const [prRecords, setPrRecords] = useState({});
 
-  if (!response.authed || response.error) return null;
-  if (response.loading) return <aha-spinner></aha-spinner>;
+  useEffect(() => {
+    let mounted = true;
+    if (!data) return;
 
-  const rows = response.data.map((pr, idx) => <PrRow key={idx} pr={pr} />);
+    const refNums = [];
+    const prsByRefNum = {};
+
+    for (let pr of data) {
+      const refNum = pr.title.split(" ")[0].toUpperCase();
+      if (!/[A-Z]+-[0-9]+/.test(refNum)) continue;
+
+      refNums.push(refNum);
+      prsByRefNum[refNum] = pr;
+    }
+
+    if (refNums.length === 0) {
+      // No records to find
+      setPrRecords({});
+      return;
+    }
+
+    aha.models.Feature.select("id", "referenceNum", "name", "path")
+      .where({
+        id: refNums,
+      })
+      .all()
+      .then((features) => {
+        if (!mounted) return;
+
+        const prRecords = {};
+        for (let feature of features) {
+          const pr = prsByRefNum[feature.referenceNum];
+          if (!pr) continue;
+          prRecords[pr.number] = feature;
+        }
+        setPrRecords(prRecords);
+      });
+
+    return () => {
+      mounted = false;
+    };
+  }, [data]);
+
+  if (!authed || error) return null;
+  if (loading || !data) return <aha-spinner></aha-spinner>;
+
+  const rows = data.map((pr, idx) => (
+    <PrRow key={idx} pr={pr} feature={prRecords[pr.number]} />
+  ));
 
   return (
     <table className="record-table record-table--settings-page">

--- a/src/components/page/PrTable.js
+++ b/src/components/page/PrTable.js
@@ -6,6 +6,8 @@ import { PrReviewStatus } from "../PrReviewStatus";
 import PrState from "../PrState";
 import { Status } from "../Status";
 
+const refNumMatcher = /([A-Z][A-Z0-9]*-(([E]|[0-9]+)-)?[0-9]+)/;
+
 /**
  * @typedef RowProps
  * @prop {import('../../lib/github').PrForLink} pr
@@ -68,11 +70,15 @@ const PrTable = ({ query }) => {
     const prsByRefNum = {};
 
     for (let pr of data) {
-      const refNum = pr.title.split(" ")[0].toUpperCase();
-      if (!/[A-Z]+-[0-9]+/.test(refNum)) continue;
-
-      refNums.push(refNum);
-      prsByRefNum[refNum] = pr;
+      [pr.headRef?.name.toUpperCase(), pr.title]
+        .map(String)
+        .map((s) => refNumMatcher.exec(s))
+        .forEach((match) => {
+          if (match) {
+            refNums.push(match[0]);
+            prsByRefNum[match[0]] = pr;
+          }
+        });
     }
 
     if (refNums.length === 0) {

--- a/src/lib/github.js
+++ b/src/lib/github.js
@@ -168,7 +168,7 @@ const SearchForPr = gql`
 /**
  * @param {GithubApi} api
  * @param {SearchForPrOptions} options
- * @returns {Promise<{edges: {node: PrForLink}[] | {node: PrForLinkWithStatus}[]}>}
+ * @returns {Promise<{edges: {node: PrForLink}[]}>}
  */
 export async function searchForPr(api, options) {
   const variables = { count: 20, searchQuery: options.query, ...options };


### PR DESCRIPTION
From the full page view of pull requests/branches, detect a record reference number in the branch name and show a link to the record.