### PR TITLE
DEVELOP-844: Missing fragment in graphql query causing some PR requests to fail

### DIFF
--- a/src/components/PrPanel.tsx
+++ b/src/components/PrPanel.tsx
@@ -23,7 +23,7 @@ export const PrPanel: React.FC<{
     async (api) => {
       const { edges } = await searchForPr(api, {
         query,
-        includeStatus: columns.status,
+        includeStatus: columns.checks,
         includeReviews: columns.reviews,
         includeLabels: columns.labels,
         count: 10,

--- a/src/components/Status.js
+++ b/src/components/Status.js
@@ -130,7 +130,7 @@ const FetchStatus = ({ pr }) => {
     loading,
     fetchData,
   } = useGithubApi(async (api) => {
-    if(isPrWithStatus(pr)) return pr;
+    if (isPrWithStatus(pr)) return pr;
     return await getPrByUrl(api, pr.url, { includeStatus: true });
   });
 

--- a/src/lib/github/queries.ts
+++ b/src/lib/github/queries.ts
@@ -117,6 +117,7 @@ export const GetPr = gql`
   ${PrForLinkFragment}
   ${PrStatusFragment}
   ${PrForReviewDecisionFragment}
+  ${PrLabelsFragment}
 `;
 
 export const RepoFragment = gql`


### PR DESCRIPTION
Errors showing when refreshing the github attribute

Fix missing fragment in GetPr query. Fragment needs to be present even
when not used.