### PR TITLE
Security 16 1 add logging

### DIFF
--- a/src/lib/fields.js
+++ b/src/lib/fields.js
@@ -88,8 +88,10 @@ function githubPrToPrLink(pr) {
  * @param {LinkableRecord} record
  */
 async function linkPullRequestToRecord(pr, record) {
+  console.log("Appending field to record")
   await appendField(record, PULL_REQUESTS_FIELD, githubPrToPrLink(pr));
 
+  console.log("Appending field to account")
   await appendField(aha.account, PULL_REQUESTS_FIELD, {
     id: accountPrId(pr.number, record.referenceNum),
     prNumber: pr.number,
@@ -97,6 +99,7 @@ async function linkPullRequestToRecord(pr, record) {
   });
 
   if (pr.headRef) {
+    console.log("Linking pr headeref branch to record")
     await linkBranchToRecord(pr.headRef.name, pr.repository.url, record);
   }
 }
@@ -105,9 +108,12 @@ async function linkPullRequestToRecord(pr, record) {
  * @param {Github.PrForLink} pr
  */
 async function linkPullRequest(pr) {
+  console.log('Getting record from reference')
   const record = await referenceToRecord(pr.title);
 
   if (record) {
+    console.log("Got record, linking pull request to record")
+
     await linkPullRequestToRecord(pr, record);
   }
 

--- a/src/lib/fields.js
+++ b/src/lib/fields.js
@@ -88,10 +88,10 @@ function githubPrToPrLink(pr) {
  * @param {LinkableRecord} record
  */
 async function linkPullRequestToRecord(pr, record) {
-  console.log("Appending field to record")
+  console.log("Appending field to record");
   await appendField(record, PULL_REQUESTS_FIELD, githubPrToPrLink(pr));
 
-  console.log("Appending field to account")
+  console.log("Appending field to account");
   await appendField(aha.account, PULL_REQUESTS_FIELD, {
     id: accountPrId(pr.number, record.referenceNum),
     prNumber: pr.number,
@@ -99,7 +99,7 @@ async function linkPullRequestToRecord(pr, record) {
   });
 
   if (pr.headRef) {
-    console.log("Linking pr headeref branch to record")
+    console.log("Linking pr headRef branch to record");
     await linkBranchToRecord(pr.headRef.name, pr.repository.url, record);
   }
 }
@@ -108,11 +108,11 @@ async function linkPullRequestToRecord(pr, record) {
  * @param {Github.PrForLink} pr
  */
 async function linkPullRequest(pr) {
-  console.log('Getting record from reference')
+  console.log("Getting record from reference");
   const record = await referenceToRecord(pr.title);
 
   if (record) {
-    console.log("Got record, linking pull request to record")
+    console.log("Got record, linking pull request to record");
 
     await linkPullRequestToRecord(pr, record);
   }

--- a/src/webhooks/webhook.js
+++ b/src/webhooks/webhook.js
@@ -25,24 +25,23 @@ aha.on("webhook", async ({ headers, payload }) => {
 async function handlePullRequest(payload) {
   const pr = payload.pull_request;
 
-  console.log("Linking pull request")
+  console.log("Linking pull request");
 
   // Make sure the PR is linked to its record.
   const record = await linkPullRequest(pr);
-  console.log("Done linking pull request")
-
+  console.log("Done linking pull request");
 
   // Generate events.
   if (record) {
-    console.log("Generating events");
+    console.log("Triggering event with record");
     await triggerEvent("pr", payload, record);
 
     if (pr.head?.name) {
-      console.log("Linking branch")
+      console.log("Linking branch");
       await linkBranch(pr.head.name, pr.repo.html_url);
     }
   } else {
-    console.log("null record, triggering event anyway")
+    console.log("Triggering event without record");
     await triggerEvent("pr", payload, null);
   }
 }

--- a/src/webhooks/webhook.js
+++ b/src/webhooks/webhook.js
@@ -25,17 +25,25 @@ aha.on("webhook", async ({ headers, payload }) => {
 async function handlePullRequest(payload) {
   const pr = payload.pull_request;
 
+  console.log("Linking pull request")
+
   // Make sure the PR is linked to its record.
   const record = await linkPullRequest(pr);
+  console.log("Done linking pull request")
+
 
   // Generate events.
   if (record) {
+    console.log("Generating events");
+
     if (pr.head?.name) {
+      console.log("Linking branch")
       await linkBranch(pr.head.name, pr.repo.html_url);
     }
 
     await triggerEvent("pr", payload, record);
   } else {
+    console.log("null record, triggering event anyway")
     await triggerEvent("pr", payload, null);
   }
 }

--- a/src/webhooks/webhook.js
+++ b/src/webhooks/webhook.js
@@ -35,13 +35,12 @@ async function handlePullRequest(payload) {
   // Generate events.
   if (record) {
     console.log("Generating events");
+    await triggerEvent("pr", payload, record);
 
     if (pr.head?.name) {
       console.log("Linking branch")
       await linkBranch(pr.head.name, pr.repo.html_url);
     }
-
-    await triggerEvent("pr", payload, record);
   } else {
     console.log("null record, triggering event anyway")
     await triggerEvent("pr", payload, null);


### PR DESCRIPTION
A downstream extension has stopped working correctly in response to pull request label events. At least part of the problem appears to be this error which occurs in  the github extension: https://big.aha.io/develop/extension_invocations/7041746682276685782

The error occurs before the github extension triggers the server event that the downstream extension listens to. 

To start with, i will add more logging to determine where the error is happening. I will also move the triggering of the server event to be as early as possible, in case I can get it to trigger before encountering the error and therby recover the downstream functionality. 