### PR TITLE
ADT-174 Update reference regex to account for prefixes containing numbers

### DIFF
--- a/src/lib/fields.js
+++ b/src/lib/fields.js
@@ -184,21 +184,21 @@ function extractReference(name) {
   let matches;
 
   // Requirement
-  if ((matches = name.match(/[a-z]{1,10}-[0-9]+-[0-9]+/i))) {
+  if ((matches = name.match(/[a-z][a-z0-9]{1,9}-[0-9]+-[0-9]+/i))) {
     return {
       type: "Requirement",
       referenceNum: matches[0],
     };
   }
   // Epic
-  if ((matches = name.match(/[a-z]{1,10}-E-[0-9]+/i))) {
+  if ((matches = name.match(/[a-z][a-z0-9]{1,9}-E-[0-9]+/i))) {
     return {
       type: "Epic",
       referenceNum: matches[0],
     };
   }
   // Feature
-  if ((matches = name.match(/[a-z]{1,10}-[0-9]+/i))) {
+  if ((matches = name.match(/[a-z][a-z0-9]{1,9}-[0-9]+/i))) {
     return {
       type: "Feature",
       referenceNum: matches[0],


### PR DESCRIPTION
**Issue:** A record with a valid reference prefix containing numbers, e.g. T100-1, did not get attached to PRs and could not be synced manually.

**Fix:** Updates regular expressions in `extractReference()` to account for reference prefixes that contain numbers. 