### PR TITLE
DEVELOP-1137-1 automation triggers

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,28 @@
           "entryPoint": "src/webhooks/webhook.js",
           "public": true
         }
+      },
+      "automationTriggers": {
+        "prState": {
+          "recordTypes": [
+            "Epic",
+            "Feature",
+            "Requirement"
+          ],
+          "title": "Github PR State",
+          "options": [
+            "opened",
+            "closed"
+          ]
+        },
+        "prMerged": {
+          "recordTypes": [
+            "Epic",
+            "Feature",
+            "Requirement"
+          ],
+          "title": "Github PR Merged"
+        }
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -91,30 +91,25 @@
       "endpoints": {
         "webhook": {
           "title": "Webhook from Github",
-          "entryPoint": "src/webhooks/webhook.js",
+          "entryPoint": "src/webhooks/webhook.ts",
           "public": true
         }
       },
       "automationTriggers": {
-        "prState": {
-          "recordTypes": [
-            "Epic",
-            "Feature",
-            "Requirement"
-          ],
-          "title": "Github PR State",
-          "options": [
-            "opened",
-            "closed"
-          ]
+        "draftPrOpened": {
+          "title": "Draft PR opened"
+        },
+        "prOpened": {
+          "title": "PR opened"
         },
         "prMerged": {
-          "recordTypes": [
-            "Epic",
-            "Feature",
-            "Requirement"
-          ],
-          "title": "Github PR Merged"
+          "title": "PR merged"
+        },
+        "prClosed": {
+          "title": "PR closed"
+        },
+        "prReopened": {
+          "title": "PR Re-opened"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aha-develop/github",
   "description": "GitHub",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "author": "Aha! (support@aha.io)",
   "repository": {
     "type": "git",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,5 @@
     "moduleResolution": "node",
     "target": "ES6"
   },
-  "include": [".aha-cache/aha.d.ts", "src"]
+  "include": [".aha-cache/types", "src"]
 }


### PR DESCRIPTION
- Add automation trigger
- Reimplement automation trigger as per specced events

This code reimplements doing a back lookup of the PR to record so that events can be fired for PRs linked manually without a reference num. We used to have this by storing in a single extension field on the account, but that field quickly got too big and broke aha. The new method is to use an extension field per record, which should be sustainable.