### PR TITLE
ADT-223: Fix parsing of reference numbers for workspaces with a single character

### DIFF
--- a/src/lib/fields.js
+++ b/src/lib/fields.js
@@ -217,21 +217,21 @@ function extractReferenceFromName(name) {
   let matches;
 
   // Requirement
-  if ((matches = name.match(/[a-z][a-z0-9]{1,9}-[0-9]+-[0-9]+/i))) {
+  if ((matches = name.match(/[a-z][a-z0-9]{0,9}-[0-9]+-[0-9]+/i))) {
     return {
       type: "Requirement",
       referenceNum: matches[0],
     };
   }
   // Epic
-  if ((matches = name.match(/[a-z][a-z0-9]{1,9}-E-[0-9]+/i))) {
+  if ((matches = name.match(/[a-z][a-z0-9]{0,9}-E-[0-9]+/i))) {
     return {
       type: "Epic",
       referenceNum: matches[0],
     };
   }
   // Feature
-  if ((matches = name.match(/[a-z][a-z0-9]{1,9}-[0-9]+/i))) {
+  if ((matches = name.match(/[a-z][a-z0-9]{0,9}-[0-9]+/i))) {
     return {
       type: "Feature",
       referenceNum: matches[0],


### PR DESCRIPTION
A single character prefix is a valid reference number.