### PR TITLE
ADT-449-1: The new build is rather large

### DIFF
--- a/codegen.ts
+++ b/codegen.ts
@@ -8,7 +8,7 @@ const config: CodegenConfig = {
       plugins: [
         "typescript",
         "typescript-operations",
-        "typed-document-node",
+        "./src/generated/string-typed-node.js",
       ],
       config: {
         onlyOperationTypes: true,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "@octokit/graphql-schema": "^13.6.0",
     "@octokit/webhooks-types": "^6.3.2",
     "gql-tag": "^1.0.1",
-    "inflected": "^2.1.0",
     "prettier": "^2.6.2"
   },
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aha-develop/github",
   "description": "GitHub",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "Aha! (support@aha.io)",
   "repository": {
     "type": "git",
@@ -14,7 +14,6 @@
     "@octokit/webhooks-types": "^6.3.2",
     "gql-tag": "^1.0.1",
     "inflected": "^2.1.0",
-    "moment": "^2.29.3",
     "prettier": "^2.6.2"
   },
   "license": "MIT",

--- a/src/components/PrState.tsx
+++ b/src/components/PrState.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-// @ts-ignore
-import { titleize } from "https://cdn.skypack.dev/inflected";
+import { titleize } from "inflected";
 import { IPullRequestLink } from "extension";
 
 const icon = (state: IPullRequestLink["state"]) => {

--- a/src/components/PrState.tsx
+++ b/src/components/PrState.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { titleize } from "inflected";
 import { IPullRequestLink } from "extension";
 
 const icon = (state: IPullRequestLink["state"]) => {
@@ -16,11 +15,25 @@ const icon = (state: IPullRequestLink["state"]) => {
 export const PrState: React.FC<{
   state: IPullRequestLink["state"];
 }> = ({ state }) => {
+  let label: string;
+
+  switch (state) {
+    case "closed":
+      label = "Closed";
+      break;
+    case "merged":
+      label = "Merged";
+      break;
+    case "open":
+      label = "Open";
+      break;
+  }
+
   return (
     <span className={`pr-state pr-state-${state}`}>
       <aha-flex gap="4px">
         <aha-icon icon={"fa-regular fa-" + icon(state)}></aha-icon>
-        <span>{titleize(state)}</span>
+        <span>{label}</span>
       </aha-flex>
     </span>
   );

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -3315,15 +3315,445 @@ export type SearchPullRequestQueryVariables = Exact<{
 
 export type SearchPullRequestQuery = { __typename: 'Query', search: { __typename: 'SearchResultItemConnection', edges: Array<{ __typename: 'SearchResultItemEdge', node: { __typename: 'App' } | { __typename: 'Discussion' } | { __typename: 'Issue' } | { __typename: 'MarketplaceListing' } | { __typename: 'Organization' } | { __typename: 'PullRequest', id: string, number: number, title: string, url: any, state: PullRequestState, merged: boolean, reviewDecision: PullRequestReviewDecision | null, repository: { __typename: 'Repository', name: string, url: any, databaseId: number | null }, headRef: { __typename: 'Ref', name: string } | null, commits: { __typename: 'PullRequestCommitConnection', nodes: Array<{ __typename: 'PullRequestCommit', commit: { __typename: 'Commit', oid: any, message: string, statusCheckRollup: { __typename: 'StatusCheckRollup', state: StatusState } | null, status: { __typename: 'Status', contexts: Array<{ __typename: 'StatusContext', context: string, description: string | null, targetUrl: any | null, avatarUrl: any | null, state: StatusState }> } | null, checkSuites: { __typename: 'CheckSuiteConnection', nodes: Array<{ __typename: 'CheckSuite', conclusion: CheckConclusionState | null, workflowRun: { __typename: 'WorkflowRun', createdAt: any, updatedAt: any, runNumber: number, url: any, workflow: { __typename: 'Workflow', id: string, databaseId: number | null, name: string } } | null, creator: { __typename: 'User', login: string, avatarUrl: any } | null, checkRuns: { __typename: 'CheckRunConnection', nodes: Array<{ __typename: 'CheckRun', title: string | null, text: string | null, summary: string | null, status: CheckStatusState, conclusion: CheckConclusionState | null, name: string } | null> | null } | null } | null> | null } | null } } | null> | null }, latestReviews: { __typename: 'PullRequestReviewConnection', nodes: Array<{ __typename: 'PullRequestReview', state: PullRequestReviewState } | null> | null } | null, labels: { __typename: 'LabelConnection', nodes: Array<{ __typename: 'Label', color: string, name: string } | null> | null } | null } | { __typename: 'Repository' } | { __typename: 'User' } | null } | null> | null } };
 
-export const PrStatusContextFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"PrStatusContext"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"StatusContext"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"context"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"targetUrl"}},{"kind":"Field","name":{"kind":"Name","value":"avatarUrl"}},{"kind":"Field","name":{"kind":"Name","value":"state"}}]}}]} as unknown as DocumentNode<PrStatusContextFragment, unknown>;
-export const PrCommitStatusFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"PrCommitStatus"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Commit"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"statusCheckRollup"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"state"}}]}},{"kind":"Field","name":{"kind":"Name","value":"status"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contexts"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"PrStatusContext"}}]}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"PrStatusContext"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"StatusContext"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"context"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"targetUrl"}},{"kind":"Field","name":{"kind":"Name","value":"avatarUrl"}},{"kind":"Field","name":{"kind":"Name","value":"state"}}]}}]} as unknown as DocumentNode<PrCommitStatusFragment, unknown>;
-export const CheckRunFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"CheckRun"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"CheckRun"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"text"}},{"kind":"Field","name":{"kind":"Name","value":"summary"}},{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"conclusion"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]} as unknown as DocumentNode<CheckRunFragment, unknown>;
-export const CommitCheckSuitesFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"CommitCheckSuites"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Commit"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"checkSuites"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"last"},"value":{"kind":"IntValue","value":"1"}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nodes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"conclusion"}},{"kind":"Field","name":{"kind":"Name","value":"workflowRun"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}},{"kind":"Field","name":{"kind":"Name","value":"runNumber"}},{"kind":"Field","name":{"kind":"Name","value":"url"}},{"kind":"Field","name":{"kind":"Name","value":"workflow"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"databaseId"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"creator"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Actor"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"login"}},{"kind":"Field","name":{"kind":"Name","value":"avatarUrl"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"size"},"value":{"kind":"IntValue","value":"32"}}]}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"checkRuns"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"last"},"value":{"kind":"IntValue","value":"1"}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nodes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"CheckRun"}}]}}]}}]}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"CheckRun"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"CheckRun"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"text"}},{"kind":"Field","name":{"kind":"Name","value":"summary"}},{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"conclusion"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]} as unknown as DocumentNode<CommitCheckSuitesFragment, unknown>;
-export const PrCommitFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"PrCommit"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"PullRequest"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"commits"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"last"},"value":{"kind":"IntValue","value":"1"}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nodes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"commit"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"oid"}},{"kind":"Field","name":{"kind":"Name","value":"message"}},{"kind":"FragmentSpread","name":{"kind":"Name","value":"PrCommitStatus"}},{"kind":"FragmentSpread","name":{"kind":"Name","value":"CommitCheckSuites"}}]}}]}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"PrStatusContext"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"StatusContext"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"context"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"targetUrl"}},{"kind":"Field","name":{"kind":"Name","value":"avatarUrl"}},{"kind":"Field","name":{"kind":"Name","value":"state"}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"CheckRun"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"CheckRun"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"text"}},{"kind":"Field","name":{"kind":"Name","value":"summary"}},{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"conclusion"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"PrCommitStatus"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Commit"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"statusCheckRollup"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"state"}}]}},{"kind":"Field","name":{"kind":"Name","value":"status"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contexts"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"PrStatusContext"}}]}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"CommitCheckSuites"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Commit"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"checkSuites"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"last"},"value":{"kind":"IntValue","value":"1"}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nodes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"conclusion"}},{"kind":"Field","name":{"kind":"Name","value":"workflowRun"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}},{"kind":"Field","name":{"kind":"Name","value":"runNumber"}},{"kind":"Field","name":{"kind":"Name","value":"url"}},{"kind":"Field","name":{"kind":"Name","value":"workflow"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"databaseId"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"creator"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Actor"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"login"}},{"kind":"Field","name":{"kind":"Name","value":"avatarUrl"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"size"},"value":{"kind":"IntValue","value":"32"}}]}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"checkRuns"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"last"},"value":{"kind":"IntValue","value":"1"}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nodes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"CheckRun"}}]}}]}}]}}]}}]}}]} as unknown as DocumentNode<PrCommitFragment, unknown>;
-export const PrForLinkFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"PrForLink"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"PullRequest"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"number"}},{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"url"}},{"kind":"Field","name":{"kind":"Name","value":"state"}},{"kind":"Field","name":{"kind":"Name","value":"merged"}},{"kind":"Field","name":{"kind":"Name","value":"repository"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"url"}},{"kind":"Field","name":{"kind":"Name","value":"databaseId"}}]}},{"kind":"Field","name":{"kind":"Name","value":"headRef"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]} as unknown as DocumentNode<PrForLinkFragment, unknown>;
-export const PrForReviewDecisionFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"PrForReviewDecision"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"PullRequest"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"reviewDecision"}},{"kind":"Field","name":{"kind":"Name","value":"latestReviews"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"first"},"value":{"kind":"IntValue","value":"5"}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nodes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"state"}}]}}]}}]}}]} as unknown as DocumentNode<PrForReviewDecisionFragment, unknown>;
-export const PrLabelsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"PrLabels"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"PullRequest"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"labels"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"first"},"value":{"kind":"IntValue","value":"5"}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nodes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"color"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]}}]} as unknown as DocumentNode<PrLabelsFragment, unknown>;
-export const BranchFragmentFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"BranchFragment"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Ref"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"__typename"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"target"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"oid"}},{"kind":"Field","name":{"kind":"Name","value":"commitUrl"}}]}}]}}]} as unknown as DocumentNode<BranchFragmentFragment, unknown>;
-export const RepoFragmentFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"RepoFragment"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Repository"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nameWithOwner"}},{"kind":"Field","name":{"kind":"Name","value":"refs"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"refPrefix"},"value":{"kind":"StringValue","value":"refs/heads/","block":false}},{"kind":"Argument","name":{"kind":"Name","value":"orderBy"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"field"},"value":{"kind":"EnumValue","value":"TAG_COMMIT_DATE"}},{"kind":"ObjectField","name":{"kind":"Name","value":"direction"},"value":{"kind":"EnumValue","value":"ASC"}}]}},{"kind":"Argument","name":{"kind":"Name","value":"first"},"value":{"kind":"IntValue","value":"5"}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"edges"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"node"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"BranchFragment"}}]}}]}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"BranchFragment"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Ref"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"__typename"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"target"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"oid"}},{"kind":"Field","name":{"kind":"Name","value":"commitUrl"}}]}}]}}]} as unknown as DocumentNode<RepoFragmentFragment, unknown>;
-export const GetPullRequestDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetPullRequest"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"name"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"owner"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"number"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"includeStatus"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Boolean"}},"defaultValue":{"kind":"BooleanValue","value":false}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"includeReviews"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Boolean"}},"defaultValue":{"kind":"BooleanValue","value":false}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"includeLabels"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Boolean"}},"defaultValue":{"kind":"BooleanValue","value":false}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"repository"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"name"},"value":{"kind":"Variable","name":{"kind":"Name","value":"name"}}},{"kind":"Argument","name":{"kind":"Name","value":"owner"},"value":{"kind":"Variable","name":{"kind":"Name","value":"owner"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"pullRequest"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"number"},"value":{"kind":"Variable","name":{"kind":"Name","value":"number"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"__typename"}},{"kind":"FragmentSpread","name":{"kind":"Name","value":"PrForLink"}},{"kind":"FragmentSpread","name":{"kind":"Name","value":"PrCommit"},"directives":[{"kind":"Directive","name":{"kind":"Name","value":"include"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"if"},"value":{"kind":"Variable","name":{"kind":"Name","value":"includeStatus"}}}]}]},{"kind":"FragmentSpread","name":{"kind":"Name","value":"PrForReviewDecision"},"directives":[{"kind":"Directive","name":{"kind":"Name","value":"include"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"if"},"value":{"kind":"Variable","name":{"kind":"Name","value":"includeReviews"}}}]}]},{"kind":"FragmentSpread","name":{"kind":"Name","value":"PrLabels"},"directives":[{"kind":"Directive","name":{"kind":"Name","value":"include"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"if"},"value":{"kind":"Variable","name":{"kind":"Name","value":"includeLabels"}}}]}]}]}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"PrStatusContext"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"StatusContext"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"context"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"targetUrl"}},{"kind":"Field","name":{"kind":"Name","value":"avatarUrl"}},{"kind":"Field","name":{"kind":"Name","value":"state"}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"PrCommitStatus"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Commit"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"statusCheckRollup"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"state"}}]}},{"kind":"Field","name":{"kind":"Name","value":"status"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contexts"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"PrStatusContext"}}]}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"CheckRun"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"CheckRun"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"text"}},{"kind":"Field","name":{"kind":"Name","value":"summary"}},{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"conclusion"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"CommitCheckSuites"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Commit"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"checkSuites"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"last"},"value":{"kind":"IntValue","value":"1"}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nodes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"conclusion"}},{"kind":"Field","name":{"kind":"Name","value":"workflowRun"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}},{"kind":"Field","name":{"kind":"Name","value":"runNumber"}},{"kind":"Field","name":{"kind":"Name","value":"url"}},{"kind":"Field","name":{"kind":"Name","value":"workflow"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"databaseId"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"creator"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Actor"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"login"}},{"kind":"Field","name":{"kind":"Name","value":"avatarUrl"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"size"},"value":{"kind":"IntValue","value":"32"}}]}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"checkRuns"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"last"},"value":{"kind":"IntValue","value":"1"}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nodes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"CheckRun"}}]}}]}}]}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"PrForLink"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"PullRequest"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"number"}},{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"url"}},{"kind":"Field","name":{"kind":"Name","value":"state"}},{"kind":"Field","name":{"kind":"Name","value":"merged"}},{"kind":"Field","name":{"kind":"Name","value":"repository"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"url"}},{"kind":"Field","name":{"kind":"Name","value":"databaseId"}}]}},{"kind":"Field","name":{"kind":"Name","value":"headRef"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"PrCommit"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"PullRequest"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"commits"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"last"},"value":{"kind":"IntValue","value":"1"}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nodes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"commit"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"oid"}},{"kind":"Field","name":{"kind":"Name","value":"message"}},{"kind":"FragmentSpread","name":{"kind":"Name","value":"PrCommitStatus"}},{"kind":"FragmentSpread","name":{"kind":"Name","value":"CommitCheckSuites"}}]}}]}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"PrForReviewDecision"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"PullRequest"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"reviewDecision"}},{"kind":"Field","name":{"kind":"Name","value":"latestReviews"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"first"},"value":{"kind":"IntValue","value":"5"}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nodes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"state"}}]}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"PrLabels"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"PullRequest"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"labels"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"first"},"value":{"kind":"IntValue","value":"5"}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nodes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"color"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]}}]} as unknown as DocumentNode<GetPullRequestQuery, GetPullRequestQueryVariables>;
-export const SearchPullRequestDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"SearchPullRequest"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"searchQuery"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"count"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"includeStatus"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Boolean"}},"defaultValue":{"kind":"BooleanValue","value":false}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"includeReviews"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Boolean"}},"defaultValue":{"kind":"BooleanValue","value":false}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"includeLabels"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Boolean"}},"defaultValue":{"kind":"BooleanValue","value":false}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"search"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"query"},"value":{"kind":"Variable","name":{"kind":"Name","value":"searchQuery"}}},{"kind":"Argument","name":{"kind":"Name","value":"type"},"value":{"kind":"EnumValue","value":"ISSUE"}},{"kind":"Argument","name":{"kind":"Name","value":"first"},"value":{"kind":"Variable","name":{"kind":"Name","value":"count"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"edges"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"node"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"__typename"}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"PullRequest"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"PrForLink"}},{"kind":"FragmentSpread","name":{"kind":"Name","value":"PrCommit"},"directives":[{"kind":"Directive","name":{"kind":"Name","value":"include"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"if"},"value":{"kind":"Variable","name":{"kind":"Name","value":"includeStatus"}}}]}]},{"kind":"FragmentSpread","name":{"kind":"Name","value":"PrForReviewDecision"},"directives":[{"kind":"Directive","name":{"kind":"Name","value":"include"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"if"},"value":{"kind":"Variable","name":{"kind":"Name","value":"includeReviews"}}}]}]},{"kind":"FragmentSpread","name":{"kind":"Name","value":"PrLabels"},"directives":[{"kind":"Directive","name":{"kind":"Name","value":"include"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"if"},"value":{"kind":"Variable","name":{"kind":"Name","value":"includeLabels"}}}]}]}]}}]}}]}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"PrStatusContext"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"StatusContext"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"context"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"targetUrl"}},{"kind":"Field","name":{"kind":"Name","value":"avatarUrl"}},{"kind":"Field","name":{"kind":"Name","value":"state"}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"PrCommitStatus"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Commit"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"statusCheckRollup"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"state"}}]}},{"kind":"Field","name":{"kind":"Name","value":"status"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"contexts"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"PrStatusContext"}}]}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"CheckRun"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"CheckRun"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"text"}},{"kind":"Field","name":{"kind":"Name","value":"summary"}},{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"conclusion"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"CommitCheckSuites"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Commit"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"checkSuites"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"last"},"value":{"kind":"IntValue","value":"1"}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nodes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"conclusion"}},{"kind":"Field","name":{"kind":"Name","value":"workflowRun"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}},{"kind":"Field","name":{"kind":"Name","value":"runNumber"}},{"kind":"Field","name":{"kind":"Name","value":"url"}},{"kind":"Field","name":{"kind":"Name","value":"workflow"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"databaseId"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"creator"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Actor"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"login"}},{"kind":"Field","name":{"kind":"Name","value":"avatarUrl"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"size"},"value":{"kind":"IntValue","value":"32"}}]}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"checkRuns"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"last"},"value":{"kind":"IntValue","value":"1"}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nodes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"CheckRun"}}]}}]}}]}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"PrForLink"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"PullRequest"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"number"}},{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"url"}},{"kind":"Field","name":{"kind":"Name","value":"state"}},{"kind":"Field","name":{"kind":"Name","value":"merged"}},{"kind":"Field","name":{"kind":"Name","value":"repository"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"url"}},{"kind":"Field","name":{"kind":"Name","value":"databaseId"}}]}},{"kind":"Field","name":{"kind":"Name","value":"headRef"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"PrCommit"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"PullRequest"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"commits"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"last"},"value":{"kind":"IntValue","value":"1"}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nodes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"commit"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"oid"}},{"kind":"Field","name":{"kind":"Name","value":"message"}},{"kind":"FragmentSpread","name":{"kind":"Name","value":"PrCommitStatus"}},{"kind":"FragmentSpread","name":{"kind":"Name","value":"CommitCheckSuites"}}]}}]}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"PrForReviewDecision"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"PullRequest"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"reviewDecision"}},{"kind":"Field","name":{"kind":"Name","value":"latestReviews"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"first"},"value":{"kind":"IntValue","value":"5"}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nodes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"state"}}]}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"PrLabels"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"PullRequest"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"labels"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"first"},"value":{"kind":"IntValue","value":"5"}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nodes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"color"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]}}]} as unknown as DocumentNode<SearchPullRequestQuery, SearchPullRequestQueryVariables>;
+export const PrStatusContextFragmentDoc = `fragment PrStatusContext on StatusContext {
+  context
+  description
+  targetUrl
+  avatarUrl
+  state
+}` as unknown as DocumentNode<PrStatusContextFragment, unknown>;
+export const PrCommitStatusFragmentDoc = `fragment PrCommitStatus on Commit {
+  statusCheckRollup {
+    state
+  }
+  status {
+    contexts {
+      ...PrStatusContext
+    }
+  }
+}
+
+fragment PrStatusContext on StatusContext {
+  context
+  description
+  targetUrl
+  avatarUrl
+  state
+}` as unknown as DocumentNode<PrCommitStatusFragment, unknown>;
+export const CheckRunFragmentDoc = `fragment CheckRun on CheckRun {
+  title
+  text
+  summary
+  status
+  conclusion
+  name
+}` as unknown as DocumentNode<CheckRunFragment, unknown>;
+export const CommitCheckSuitesFragmentDoc = `fragment CommitCheckSuites on Commit {
+  checkSuites(last: 1) {
+    nodes {
+      conclusion
+      workflowRun {
+        createdAt
+        updatedAt
+        runNumber
+        url
+        workflow {
+          id
+          databaseId
+          name
+        }
+      }
+      creator {
+        ... on Actor {
+          login
+          avatarUrl(size: 32)
+        }
+      }
+      checkRuns(last: 1) {
+        nodes {
+          ...CheckRun
+        }
+      }
+    }
+  }
+}
+
+fragment CheckRun on CheckRun {
+  title
+  text
+  summary
+  status
+  conclusion
+  name
+}` as unknown as DocumentNode<CommitCheckSuitesFragment, unknown>;
+export const PrCommitFragmentDoc = `fragment PrCommit on PullRequest {
+  commits(last: 1) {
+    nodes {
+      commit {
+        oid
+        message
+        ...PrCommitStatus
+        ...CommitCheckSuites
+      }
+    }
+  }
+}
+
+fragment PrStatusContext on StatusContext {
+  context
+  description
+  targetUrl
+  avatarUrl
+  state
+}
+
+fragment CheckRun on CheckRun {
+  title
+  text
+  summary
+  status
+  conclusion
+  name
+}
+
+fragment PrCommitStatus on Commit {
+  statusCheckRollup {
+    state
+  }
+  status {
+    contexts {
+      ...PrStatusContext
+    }
+  }
+}
+
+fragment CommitCheckSuites on Commit {
+  checkSuites(last: 1) {
+    nodes {
+      conclusion
+      workflowRun {
+        createdAt
+        updatedAt
+        runNumber
+        url
+        workflow {
+          id
+          databaseId
+          name
+        }
+      }
+      creator {
+        ... on Actor {
+          login
+          avatarUrl(size: 32)
+        }
+      }
+      checkRuns(last: 1) {
+        nodes {
+          ...CheckRun
+        }
+      }
+    }
+  }
+}` as unknown as DocumentNode<PrCommitFragment, unknown>;
+export const PrForLinkFragmentDoc = `fragment PrForLink on PullRequest {
+  id
+  number
+  title
+  url
+  state
+  merged
+  repository {
+    name
+    url
+    databaseId
+  }
+  headRef {
+    name
+  }
+}` as unknown as DocumentNode<PrForLinkFragment, unknown>;
+export const PrForReviewDecisionFragmentDoc = `fragment PrForReviewDecision on PullRequest {
+  reviewDecision
+  latestReviews(first: 5) {
+    nodes {
+      state
+    }
+  }
+}` as unknown as DocumentNode<PrForReviewDecisionFragment, unknown>;
+export const PrLabelsFragmentDoc = `fragment PrLabels on PullRequest {
+  labels(first: 5) {
+    nodes {
+      color
+      name
+    }
+  }
+}` as unknown as DocumentNode<PrLabelsFragment, unknown>;
+export const BranchFragmentFragmentDoc = `fragment BranchFragment on Ref {
+  __typename
+  name
+  target {
+    oid
+    commitUrl
+  }
+}` as unknown as DocumentNode<BranchFragmentFragment, unknown>;
+export const RepoFragmentFragmentDoc = `fragment RepoFragment on Repository {
+  nameWithOwner
+  refs(
+    refPrefix: "refs/heads/"
+    orderBy: {field: TAG_COMMIT_DATE, direction: ASC}
+    first: 5
+  ) {
+    edges {
+      node {
+        ...BranchFragment
+      }
+    }
+  }
+}
+
+fragment BranchFragment on Ref {
+  __typename
+  name
+  target {
+    oid
+    commitUrl
+  }
+}` as unknown as DocumentNode<RepoFragmentFragment, unknown>;
+export const GetPullRequestDocument = `query GetPullRequest($name: String!, $owner: String!, $number: Int!, $includeStatus: Boolean = false, $includeReviews: Boolean = false, $includeLabels: Boolean = false) {
+  repository(name: $name, owner: $owner) {
+    pullRequest(number: $number) {
+      __typename
+      ...PrForLink
+      ...PrCommit @include(if: $includeStatus)
+      ...PrForReviewDecision @include(if: $includeReviews)
+      ...PrLabels @include(if: $includeLabels)
+    }
+  }
+}
+
+fragment PrStatusContext on StatusContext {
+  context
+  description
+  targetUrl
+  avatarUrl
+  state
+}
+
+fragment PrCommitStatus on Commit {
+  statusCheckRollup {
+    state
+  }
+  status {
+    contexts {
+      ...PrStatusContext
+    }
+  }
+}
+
+fragment CheckRun on CheckRun {
+  title
+  text
+  summary
+  status
+  conclusion
+  name
+}
+
+fragment CommitCheckSuites on Commit {
+  checkSuites(last: 1) {
+    nodes {
+      conclusion
+      workflowRun {
+        createdAt
+        updatedAt
+        runNumber
+        url
+        workflow {
+          id
+          databaseId
+          name
+        }
+      }
+      creator {
+        ... on Actor {
+          login
+          avatarUrl(size: 32)
+        }
+      }
+      checkRuns(last: 1) {
+        nodes {
+          ...CheckRun
+        }
+      }
+    }
+  }
+}
+
+fragment PrForLink on PullRequest {
+  id
+  number
+  title
+  url
+  state
+  merged
+  repository {
+    name
+    url
+    databaseId
+  }
+  headRef {
+    name
+  }
+}
+
+fragment PrCommit on PullRequest {
+  commits(last: 1) {
+    nodes {
+      commit {
+        oid
+        message
+        ...PrCommitStatus
+        ...CommitCheckSuites
+      }
+    }
+  }
+}
+
+fragment PrForReviewDecision on PullRequest {
+  reviewDecision
+  latestReviews(first: 5) {
+    nodes {
+      state
+    }
+  }
+}
+
+fragment PrLabels on PullRequest {
+  labels(first: 5) {
+    nodes {
+      color
+      name
+    }
+  }
+}` as unknown as DocumentNode<GetPullRequestQuery, GetPullRequestQueryVariables>;
+export const SearchPullRequestDocument = `query SearchPullRequest($searchQuery: String!, $count: Int!, $includeStatus: Boolean = false, $includeReviews: Boolean = false, $includeLabels: Boolean = false) {
+  search(query: $searchQuery, type: ISSUE, first: $count) {
+    edges {
+      node {
+        __typename
+        ... on PullRequest {
+          ...PrForLink
+          ...PrCommit @include(if: $includeStatus)
+          ...PrForReviewDecision @include(if: $includeReviews)
+          ...PrLabels @include(if: $includeLabels)
+        }
+      }
+    }
+  }
+}
+
+fragment PrStatusContext on StatusContext {
+  context
+  description
+  targetUrl
+  avatarUrl
+  state
+}
+
+fragment PrCommitStatus on Commit {
+  statusCheckRollup {
+    state
+  }
+  status {
+    contexts {
+      ...PrStatusContext
+    }
+  }
+}
+
+fragment CheckRun on CheckRun {
+  title
+  text
+  summary
+  status
+  conclusion
+  name
+}
+
+fragment CommitCheckSuites on Commit {
+  checkSuites(last: 1) {
+    nodes {
+      conclusion
+      workflowRun {
+        createdAt
+        updatedAt
+        runNumber
+        url
+        workflow {
+          id
+          databaseId
+          name
+        }
+      }
+      creator {
+        ... on Actor {
+          login
+          avatarUrl(size: 32)
+        }
+      }
+      checkRuns(last: 1) {
+        nodes {
+          ...CheckRun
+        }
+      }
+    }
+  }
+}
+
+fragment PrForLink on PullRequest {
+  id
+  number
+  title
+  url
+  state
+  merged
+  repository {
+    name
+    url
+    databaseId
+  }
+  headRef {
+    name
+  }
+}
+
+fragment PrCommit on PullRequest {
+  commits(last: 1) {
+    nodes {
+      commit {
+        oid
+        message
+        ...PrCommitStatus
+        ...CommitCheckSuites
+      }
+    }
+  }
+}
+
+fragment PrForReviewDecision on PullRequest {
+  reviewDecision
+  latestReviews(first: 5) {
+    nodes {
+      state
+    }
+  }
+}
+
+fragment PrLabels on PullRequest {
+  labels(first: 5) {
+    nodes {
+      color
+      name
+    }
+  }
+}` as unknown as DocumentNode<SearchPullRequestQuery, SearchPullRequestQueryVariables>;

--- a/src/generated/string-typed-node.js
+++ b/src/generated/string-typed-node.js
@@ -1,6 +1,13 @@
 // @ts-nocheck
 "use strict";
-const { extname } = require("path");
+
+/**
+ * This file is a copy of document-typed-node but it outputs graphql strings
+ * instead of compiled graphql document nodes. The reason to do this is that to
+ * parse the documents again to send with queries requires importing print from
+ * graphql, which adds a significant amount of code to the output bundle.
+ */
+
 const { print } = require("graphql");
 const { oldVisit } = require("@graphql-codegen/plugin-helpers");
 const {

--- a/src/generated/string-typed-node.js
+++ b/src/generated/string-typed-node.js
@@ -1,0 +1,135 @@
+// @ts-nocheck
+"use strict";
+const { extname } = require("path");
+const { print } = require("graphql");
+const { oldVisit } = require("@graphql-codegen/plugin-helpers");
+const {
+  optimizeOperations,
+} = require("@graphql-codegen/visitor-plugin-common");
+const { concatAST, Kind } = require("graphql");
+const tslib_1 = require("tslib");
+const visitor_plugin_common_1 = require("@graphql-codegen/visitor-plugin-common");
+const auto_bind_1 = tslib_1.__importDefault(require("auto-bind"));
+
+class TypeScriptDocumentNodesVisitor extends visitor_plugin_common_1.ClientSideBaseVisitor {
+  constructor(schema, fragments, config, documents) {
+    super(
+      schema,
+      fragments,
+      {
+        documentMode:
+          visitor_plugin_common_1.DocumentMode.documentNodeImportFragments,
+        documentNodeImport:
+          "@graphql-typed-document-node/core#TypedDocumentNode",
+        ...config,
+      },
+      {},
+      documents
+    );
+    this.pluginConfig = config;
+    (0, auto_bind_1.default)(this);
+    // We need to make sure it's there because in this mode, the base plugin doesn't add the import
+    if (
+      this.config.documentMode ===
+      visitor_plugin_common_1.DocumentMode.graphQLTag
+    ) {
+      const documentNodeImport = this._parseImport(
+        this.config.documentNodeImport || "graphql#DocumentNode"
+      );
+      const tagImport = this._generateImport(
+        documentNodeImport,
+        "DocumentNode",
+        true
+      );
+      this._imports.add(tagImport);
+    }
+  }
+  SelectionSet(node, _, parent) {
+    if (!this.pluginConfig.addTypenameToSelectionSets) {
+      return;
+    }
+    // Don't add __typename to OperationDefinitions.
+    if (parent && parent.kind === "OperationDefinition") {
+      return;
+    }
+    // No changes if no selections.
+    const { selections } = node;
+    if (!selections) {
+      return;
+    }
+    // If selections already have a __typename or is introspection do nothing.
+    const hasTypename = selections.some(
+      (selection) =>
+        selection.kind === "Field" &&
+        (selection.name.value === "__typename" ||
+          selection.name.value.lastIndexOf("__", 0) === 0)
+    );
+    if (hasTypename) {
+      return;
+    }
+    return {
+      ...node,
+      selections: [
+        ...selections,
+        {
+          kind: "Field",
+          name: {
+            kind: "Name",
+            value: "__typename",
+          },
+        },
+      ],
+    };
+  }
+  getDocumentNodeSignature(resultType, variablesTypes, node) {
+    if (
+      this.config.documentMode ===
+        visitor_plugin_common_1.DocumentMode.documentNode ||
+      this.config.documentMode ===
+        visitor_plugin_common_1.DocumentMode.documentNodeImportFragments ||
+      this.config.documentMode ===
+        visitor_plugin_common_1.DocumentMode.graphQLTag
+    ) {
+      return ` as unknown as DocumentNode<${resultType}, ${variablesTypes}>`;
+    }
+    return super.getDocumentNodeSignature(resultType, variablesTypes, node);
+  }
+  _gql(node) {
+    const document = super._gql(node);
+    return "`" + print(JSON.parse(document)) + "`";
+  }
+}
+
+module.exports = {
+  plugin: (schema, rawDocuments, config) => {
+    const documents = config.flattenGeneratedTypes
+      ? optimizeOperations(schema, rawDocuments)
+      : rawDocuments;
+    const allAst = concatAST(documents.map((v) => v.document));
+    const allFragments = [
+      ...allAst.definitions
+        .filter((d) => d.kind === Kind.FRAGMENT_DEFINITION)
+        .map((fragmentDef) => ({
+          node: fragmentDef,
+          name: fragmentDef.name.value,
+          onType: fragmentDef.typeCondition.name.value,
+          isExternal: false,
+        })),
+      ...(config.externalFragments || []),
+    ];
+    const visitor = new TypeScriptDocumentNodesVisitor(
+      schema,
+      allFragments,
+      config,
+      documents
+    );
+    const visitorResult = oldVisit(allAst, { leave: visitor });
+    return {
+      prepend: allAst.definitions.length === 0 ? [] : visitor.getImports(),
+      content: [
+        visitor.fragments,
+        ...visitorResult.definitions.filter((t) => typeof t === "string"),
+      ].join("\n"),
+    };
+  },
+};

--- a/src/lib/calcTimeElapsed.ts
+++ b/src/lib/calcTimeElapsed.ts
@@ -1,12 +1,43 @@
-import moment from "moment";
-
 /**
  * Calculate Elapsed Time
  */
-export const calcTimeElapsed = (date: Date | string | number): string => {
-  if (date instanceof Date) {
-    return moment(date).fromNow();
+export function calcTimeElapsed(inputDate: Date | string) {
+  const date = inputDate instanceof Date ? inputDate : new Date(inputDate);
+
+  const now = new Date();
+  const diff = now.getTime() - date.getTime();
+  if (Number.isNaN(diff)) return "";
+
+  const seconds = diff / 1000;
+  const minutes = seconds / 60;
+  const hours = minutes / 60;
+  const days = hours / 24;
+  const weeks = days / 7;
+  const months = days / 30;
+  const years = days / 365;
+
+  if (seconds < 45) {
+    return "a few seconds ago";
+  } else if (years >= 1) {
+    const roundedYears = Math.round(years);
+    return `${roundedYears} year${roundedYears !== 1 ? "s" : ""} ago`;
+  } else if (months >= 1) {
+    const roundedMonths = Math.round(months);
+    return `${roundedMonths} month${roundedMonths !== 1 ? "s" : ""} ago`;
+  } else if (weeks >= 1) {
+    const roundedWeeks = Math.round(weeks);
+    return `${roundedWeeks} week${roundedWeeks !== 1 ? "s" : ""} ago`;
+  } else if (days >= 1) {
+    const roundedDays = Math.round(days);
+    return `${roundedDays} day${roundedDays !== 1 ? "s" : ""} ago`;
+  } else if (hours >= 1) {
+    const roundedHours = Math.round(hours);
+    return `${roundedHours} hour${roundedHours !== 1 ? "s" : ""} ago`;
+  } else if (minutes >= 1) {
+    const roundedMinutes = Math.round(minutes);
+    return `${roundedMinutes} minute${roundedMinutes !== 1 ? "s" : ""} ago`;
   } else {
-    return moment(new Date(date)).fromNow();
+    const roundedSeconds = Math.round(seconds);
+    return `${roundedSeconds} second${roundedSeconds !== 1 ? "s" : ""} ago`;
   }
-};
+}

--- a/src/lib/extractReferenceFromName.test.ts
+++ b/src/lib/extractReferenceFromName.test.ts
@@ -1,0 +1,47 @@
+import { extractReferenceFromName } from "./extractReferenceFromName";
+
+describe("extractReferenceFromName  ", () => {
+  it("should return null if no match", () => {
+    expect(extractReferenceFromName("foo")).toBe(null);
+  });
+
+  it("returns Requirement", () => {
+    expect(extractReferenceFromName("FEAT-123-1")).toEqual({
+      type: "Requirement",
+      referenceNum: "FEAT-123-1",
+    });
+    expect(extractReferenceFromName("in a sentence FEAT-123-1")).toEqual({
+      type: "Requirement",
+      referenceNum: "FEAT-123-1",
+    });
+  });
+
+  it("returns Epic", () => {
+    expect(extractReferenceFromName("FEAT-E-123")).toEqual({
+      type: "Epic",
+      referenceNum: "FEAT-E-123",
+    });
+    expect(extractReferenceFromName("in a sentence FEAT-E-123")).toEqual({
+      type: "Epic",
+      referenceNum: "FEAT-E-123",
+    });
+  });
+
+  it("returns Feature", () => {
+    expect(extractReferenceFromName("FEAT-123")).toEqual({
+      type: "Feature",
+      referenceNum: "FEAT-123",
+    });
+    expect(extractReferenceFromName("in a sentence FEAT-123")).toEqual({
+      type: "Feature",
+      referenceNum: "FEAT-123",
+    });
+  });
+
+  it("returns the first match", () => {
+    expect(extractReferenceFromName("with FEAT-123-1 I'm fixing issues that were found in FEAT-122 of epic FEAT-E-121")).toEqual({
+      type: "Requirement",
+      referenceNum: "FEAT-123-1",
+    });
+  })
+});

--- a/src/lib/github/api.ts
+++ b/src/lib/github/api.ts
@@ -1,5 +1,5 @@
-import { DocumentNode, print } from "graphql";
 import { TypedDocumentNode } from "@graphql-typed-document-node/core";
+import { DocumentNode } from "graphql";
 
 /**
  * Wrap the github provided graphql function in a function that accepts a
@@ -13,10 +13,14 @@ function toFetch(token: string) {
     variables?: TVariables
   ): Promise<TData>;
   async function gqlFetch<TData = any, TVariables = Record<string, any>>(
-    operation: DocumentNode,
+    operation: DocumentNode|string,
+    variables?: TVariables
+  ): Promise<TData>;
+  async function gqlFetch<TData = any, TVariables = Record<string, any>>(
+    operation: any,
     variables?: TVariables
   ): Promise<TData> {
-    const query = print(operation);
+    const query = operation;
     const payload: any = { query };
     if (variables) payload.variables = variables;
 

--- a/src/lib/github/recentBranches.ts
+++ b/src/lib/github/recentBranches.ts
@@ -2,8 +2,6 @@ import {
   RepoFragmentFragment,
   RepoFragmentFragmentDoc,
 } from "generated/graphql";
-import gql from "gql-tag";
-import { print, parse } from "graphql";
 import { classify } from "inflected";
 import { GqlFetch } from "./api";
 
@@ -12,7 +10,7 @@ const repoAlias = (repo: string) => classify(repo).replace(/[^a-zA-Z]/g, "");
 const RepoBranches = (repo: string) => {
   const alias = repoAlias(repo);
 
-  return gql`
+  return `
     ${alias}: repository(name: $${alias}Name, owner: $${alias}Owner) {
       ...RepoFragment
     }
@@ -37,16 +35,16 @@ export async function recentBranches(api: GqlFetch, repos: string[]) {
     [[] as string[], {} as Record<string, string>]
   );
 
-  const query = gql`
+  const query = `
     query GetRecentBranches(${queryArgs.join(", ")}) {
       ${repos.map(RepoBranches).join("\n")}
     }
 
-    ${print(RepoFragmentFragmentDoc)}
+    ${RepoFragmentFragmentDoc}
   `;
 
   const data = await api<Record<string, RepoFragmentFragment>>(
-    parse(query),
+    query,
     queryVars
   );
   return repoAliases.map((alias) => data[alias]);

--- a/src/lib/github/recentBranches.ts
+++ b/src/lib/github/recentBranches.ts
@@ -2,10 +2,9 @@ import {
   RepoFragmentFragment,
   RepoFragmentFragmentDoc,
 } from "generated/graphql";
-import { classify } from "inflected";
 import { GqlFetch } from "./api";
 
-const repoAlias = (repo: string) => classify(repo).replace(/[^a-zA-Z]/g, "");
+const repoAlias = (repo: string) => repo.replace(/[^a-zA-Z]/g, "");
 
 const RepoBranches = (repo: string) => {
   const alias = repoAlias(repo);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2960,11 +2960,6 @@ indent-string@^4.0.0:
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
   integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
 
-inflected@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/inflected/-/inflected-2.1.0.tgz#2816ac17a570bbbc8303ca05bca8bf9b3f959687"
-  integrity sha512-hAEKNxvHf2Iq3H60oMBHkB4wl5jn3TPF3+fXek/sRwAB5gP9xWs4r7aweSF95f99HFoz69pnZTcu8f0SIHV18w==
-
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3788,11 +3788,6 @@ minimatch@^3.0.4, minimatch@^3.1.1:
   dependencies:
     brace-expansion "^1.1.7"
 
-moment@^2.29.3:
-  version "2.29.4"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
-  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
-
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"


### PR DESCRIPTION
Shrink the built file by removing as many external dependencies as possible:

- Add test for extractReferenceFromName
- Remove inflected, we only used it to titleize PR state
- Use string graphql queries so that graphql print does not need importing
- Use fetch directly instead of using @octokit/graphql
- Remove moment by replacing the single function it uses

This takes the built gz file from 289kb to 114kb