### PR TITLE
DEVELOP-1678 Prioritize title over url when linking prs to records

### DIFF
--- a/src/lib/recordFrom.ts
+++ b/src/lib/recordFrom.ts
@@ -147,8 +147,8 @@ export async function recordFromPullRequestEvent(
   pr: PullRequestEvent["pull_request"]
 ): Promise<LinkableRecord | null> {
   return recordFromFinders([
-    ["PR URL", () => recordFromUrl(pr.html_url)],
     ["PR Title", () => recordFromReferenceNum(pr.title)],
+    ["PR URL", () => recordFromUrl(pr.html_url)],
     ["PR branch name", () => recordFromReferenceNum(pr.head.ref)],
     [
       "PR branch URL",


### PR DESCRIPTION
### Once merged, please bump the mintor version to `2.1.0`

- https://big.aha.io/features/DEVELOP-1678

During the large, recent refactor by @jemmyw the behavior where changing a pr title would relink a feature to the new refnum contained in the title was inadvertently changed.

This reintroduces that prior behavior by prioritizing the title over the url when looking up a feature in response to a webhook update of a pull request.

I'm unsure if this constitutes a bump from `2.0.1` -> `2.0.2`, or a minor bump of `2.0.1` -> `2.1.0`.