### PR TITLE
Adds missing popperjs/core dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "@octokit/webhooks-types": "^6.3.2",
     "gql-tag": "^1.0.1",
     "prettier": "^2.6.2",
-    "react-popper": "^2.3.0"
+    "react-popper": "^2.3.0",
+    "@popperjs/core": "^2.11.8"
   },
   "license": "MIT",
   "ahaExtension": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1579,6 +1579,11 @@
     tslib "^2.4.1"
     webcrypto-core "^1.7.4"
 
+"@popperjs/core@^2.11.8":
+  version "2.11.8"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
+  integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
+
 "@repeaterjs/repeater@3.0.4", "@repeaterjs/repeater@^3.0.4":
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/@repeaterjs/repeater/-/repeater-3.0.4.tgz#a04d63f4d1bf5540a41b01a921c9a7fddc3bd1ca"


### PR DESCRIPTION
Quick fix for the 2.3.0 release - react-popper has a dependency on popperjs-core which wasn't picked up until attempted to build.